### PR TITLE
Improve tab scaling

### DIFF
--- a/codes/gui/main_window/theme_mixin.py
+++ b/codes/gui/main_window/theme_mixin.py
@@ -120,11 +120,12 @@ class ThemeMixin:
                 border-bottom: none;
                 border-top-left-radius: 8px;
                 border-top-right-radius: 8px;
-                padding: 10px 20px;
+                padding: 6px 14px;
                 margin-right: 3px;
                 font-weight: 500;
-                min-width: 120px;
-                min-height: 30px;
+                min-width: 100px;
+                min-height: 28px;
+                icon-size: 20px;
             }}
             QTabBar::tab:selected {{
                 background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
@@ -132,15 +133,17 @@ class ThemeMixin:
                 color: #FFFFFF;
                 border-bottom: 3px solid {tertiary_color.name()};
                 font-weight: bold;
-                min-width: 120px;
-                min-height: 30px;
+                min-width: 100px;
+                min-height: 28px;
+                icon-size: 20px;
             }}
             QTabBar::tab:hover {{
                 background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
                     stop: 0 #2D2D3D, stop: 1 #252530);
                 color: #FFFFFF;
-                min-width: 120px;
-                min-height: 30px;
+                min-width: 100px;
+                min-height: 28px;
+                icon-size: 20px;
             }}
             QScrollArea, QScrollBar {{
                 border: none;
@@ -566,11 +569,12 @@ class ThemeMixin:
                 border-bottom: none;
                 border-top-left-radius: 8px;
                 border-top-right-radius: 8px;
-                padding: 10px 20px;
+                padding: 6px 14px;
                 margin-right: 3px;
                 font-weight: 500;
-                min-width: 120px;
-                min-height: 30px;
+                min-width: 100px;
+                min-height: 28px;
+                icon-size: 20px;
             }}
             QTabBar::tab:selected {{
                 background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
@@ -578,15 +582,17 @@ class ThemeMixin:
                 color: #FFFFFF;
                 border-bottom: 3px solid {tertiary_color.name()};
                 font-weight: bold;
-                min-width: 120px;
-                min-height: 30px;
+                min-width: 100px;
+                min-height: 28px;
+                icon-size: 20px;
             }}
             QTabBar::tab:hover {{
                 background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
                     stop: 0 #EEEEEE, stop: 1 #E5E5EA);
                 color: {text_color.name()};
-                min-width: 120px;
-                min-height: 30px;
+                min-width: 100px;
+                min-height: 28px;
+                icon-size: 20px;
             }}
             QScrollArea, QScrollBar {{
                 border: none;

--- a/codes/gui/widgets.py
+++ b/codes/gui/widgets.py
@@ -1,6 +1,6 @@
 from PyQt5.QtWidgets import QTabWidget, QWidget, QHBoxLayout, QLabel
 from PyQt5.QtGui import QPixmap, QFont, QCursor
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, QSize
 
 class ModernQTabWidget(QTabWidget):
     """Custom TabWidget with modern styling"""
@@ -9,6 +9,10 @@ class ModernQTabWidget(QTabWidget):
         self.setDocumentMode(True)
         self.setTabPosition(QTabWidget.North)
         self.setMovable(True)
+        # Ensure tabs adapt nicely on smaller screens
+        self.tabBar().setElideMode(Qt.ElideRight)
+        self.tabBar().setUsesScrollButtons(True)
+        self.tabBar().setIconSize(QSize(20, 20))
 
 class SidebarButton(QWidget):
     """Elegant sidebar button with modern styling and animations"""
@@ -21,7 +25,8 @@ class SidebarButton(QWidget):
         if icon_path:
             icon = QLabel()
             pixmap = QPixmap(icon_path)
-            icon.setPixmap(pixmap.scaled(28, 28, Qt.KeepAspectRatio, Qt.SmoothTransformation))
+            # Scale sidebar icons to a reasonable size
+            icon.setPixmap(pixmap.scaled(20, 20, Qt.KeepAspectRatio, Qt.SmoothTransformation))
             layout.addWidget(icon)
 
         label = QLabel(text)


### PR DESCRIPTION
## Summary
- refine tab and sidebar button styling
- shrink icon sizes
- let tabs elide long titles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687628295cd08329ab6aa7924551e12b