### PR TITLE
Add omega sensitivity GUI visualizations

### DIFF
--- a/codes/gui/main_window/omega_sensitivity_mixin.py
+++ b/codes/gui/main_window/omega_sensitivity_mixin.py
@@ -242,7 +242,14 @@ class OmegaSensitivityMixin:
             if not hasattr(self, 'rel_change_fig') or self.rel_change_fig is None:
                 QMessageBox.warning(self, "Error", "No relative change plot to save.")
                 return
-                
+
             self.save_plot(self.rel_change_fig, "Relative_Change_Analysis")
+
+        else:  # Combined view
+            if not hasattr(self, 'combined_fig') or self.combined_fig is None:
+                QMessageBox.warning(self, "Error", "No combined plot to save.")
+                return
+
+            self.save_plot(self.combined_fig, "Combined_Analysis")
     
 


### PR DESCRIPTION
## Summary
- add missing Omega sensitivity tab setup in the GUI
- include a new combined view with dual‑axis plot
- allow saving combined view figures

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6876536978b88329a62b906c45292f70