### PR TITLE
Fix GA run details tab selection

### DIFF
--- a/codes/gui/main_window/ga_mixin.py
+++ b/codes/gui/main_window/ga_mixin.py
@@ -411,6 +411,7 @@ class GAOptimizationMixin:
         
         # Summary statistics tabs (create subtabs for better organization)
         stats_tab = QWidget()
+        stats_tab.setObjectName("stats_tab")
         stats_layout = QVBoxLayout(stats_tab)
         
         # Create a tabbed widget for the statistics section
@@ -3384,9 +3385,11 @@ class GAOptimizationMixin:
             # Make sure all tabs in the main tab widget are preserved and properly displayed
             if hasattr(self, 'benchmark_viz_tabs'):
                 # First, switch to the Statistics tab to make the details visible
-                stats_tab_index = self.benchmark_viz_tabs.indexOf(self.benchmark_viz_tabs.findChild(QWidget, "stats_tab"))
-                if stats_tab_index == -1:  # If not found by name, try finding by index
-                    stats_tab_index = 5  # Statistics tab is typically the 6th tab (index 5)
+                stats_tab_index = self.benchmark_viz_tabs.indexOf(
+                    self.benchmark_viz_tabs.findChild(QWidget, "stats_tab")
+                )
+                if stats_tab_index == -1:  # If not found by name, fall back to the last tab
+                    stats_tab_index = self.benchmark_viz_tabs.count() - 1  # Statistics tab is the last one
                 
                 # Switch to the stats tab
                 self.benchmark_viz_tabs.setCurrentIndex(stats_tab_index)


### PR DESCRIPTION
## Summary
- ensure the GA statistics tab has an object name for lookup
- default to the last tab when switching to Statistics tab

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68788202fa188329b8c151e4284a4fb1