### PR TITLE
Fix stats tab selection bug

### DIFF
--- a/codes/gui/main_window/ga_mixin.py
+++ b/codes/gui/main_window/ga_mixin.py
@@ -411,6 +411,7 @@ class GAOptimizationMixin:
         
         # Summary statistics tabs (create subtabs for better organization)
         stats_tab = QWidget()
+        stats_tab.setObjectName("stats_tab")
         stats_layout = QVBoxLayout(stats_tab)
         
         # Create a tabbed widget for the statistics section
@@ -3384,12 +3385,10 @@ class GAOptimizationMixin:
             # Make sure all tabs in the main tab widget are preserved and properly displayed
             if hasattr(self, 'benchmark_viz_tabs'):
                 # First, switch to the Statistics tab to make the details visible
-                stats_tab_index = self.benchmark_viz_tabs.indexOf(self.benchmark_viz_tabs.findChild(QWidget, "stats_tab"))
-                if stats_tab_index == -1:  # If not found by name, try finding by index
-                    stats_tab_index = 5  # Statistics tab is typically the 6th tab (index 5)
-                
-                # Switch to the stats tab
-                self.benchmark_viz_tabs.setCurrentIndex(stats_tab_index)
+                stats_tab = self.benchmark_viz_tabs.findChild(QWidget, "stats_tab")
+                stats_tab_index = self.benchmark_viz_tabs.indexOf(stats_tab)
+                if stats_tab_index != -1:
+                    self.benchmark_viz_tabs.setCurrentIndex(stats_tab_index)
                 
                 # Make sure all tabs and their contents are visible
                 for i in range(self.benchmark_viz_tabs.count()):

--- a/codes/gui/main_window/pso_mixin.py
+++ b/codes/gui/main_window/pso_mixin.py
@@ -339,6 +339,7 @@ class PSOMixin:
         
         # Summary statistics tabs (create subtabs for better organization)
         pso_stats_tab = QWidget()
+        pso_stats_tab.setObjectName("pso_stats_tab")
         pso_stats_layout = QVBoxLayout(pso_stats_tab)
         
         # Create a tabbed widget for the statistics section
@@ -1683,12 +1684,10 @@ class PSOMixin:
             # Make sure all tabs in the main tab widget are preserved and properly displayed
             if hasattr(self, 'pso_benchmark_viz_tabs'):
                 # First, switch to the Statistics tab to make the details visible
-                stats_tab_index = self.pso_benchmark_viz_tabs.indexOf(self.pso_benchmark_viz_tabs.findChild(QWidget, "pso_stats_tab"))
-                if stats_tab_index == -1:  # If not found by name, try finding by index
-                    stats_tab_index = 5  # Statistics tab is typically the 6th tab (index 5)
-                
-                # Switch to the stats tab
-                self.pso_benchmark_viz_tabs.setCurrentIndex(stats_tab_index)
+                stats_tab = self.pso_benchmark_viz_tabs.findChild(QWidget, "pso_stats_tab")
+                stats_tab_index = self.pso_benchmark_viz_tabs.indexOf(stats_tab)
+                if stats_tab_index != -1:
+                    self.pso_benchmark_viz_tabs.setCurrentIndex(stats_tab_index)
                 
                 # Make sure all tabs and their contents are visible
                 for i in range(self.pso_benchmark_viz_tabs.count()):


### PR DESCRIPTION
## Summary
- set object names for GA/PSO stats tabs
- locate stats tab by object name when viewing run details

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687b40cb7758832a8d478068fe89b89a