### PR TITLE
Fix GA active parameter display

### DIFF
--- a/codes/gui/main_window/ga_mixin.py
+++ b/codes/gui/main_window/ga_mixin.py
@@ -6240,6 +6240,8 @@ All parameters remain constant during optimization.''',
                 param_pairs = [(name, val) for name, val in zip(param_names, best_solution) if abs(val) > 1e-6]
 
             if param_pairs:
+                fig_height = max(6, 0.4 * len(param_pairs))
+                fig.set_size_inches(12, fig_height)
                 names, values = zip(*param_pairs)
                 y_pos = range(len(names))
 


### PR DESCRIPTION
## Summary
- resize fitness component plot dynamically to display all active parameters

## Testing
- `python -m py_compile codes/gui/main_window/ga_mixin.py`


------
https://chatgpt.com/codex/tasks/task_e_688cd1f4c26c832a96fc370d5327174a