### PR TITLE
Fix evaluation counter in GA fallback path

### DIFF
--- a/codes/workers/GAWorker.py
+++ b/codes/workers/GAWorker.py
@@ -1426,9 +1426,10 @@ class GAWorker(QThread):
                     else:
                         # Fallback: evaluate all invalids
                         self.update.emit(f"  Evaluating {len(invalid_ind)} individuals...")
-                    fitnesses = map(toolbox.evaluate, invalid_ind)
-                    for ind, fit in zip(invalid_ind, fitnesses):
-                        ind.fitness.values = fit
+                        fitnesses = map(toolbox.evaluate, invalid_ind)
+                        for ind, fit in zip(invalid_ind, fitnesses):
+                            ind.fitness.values = fit
+                        # Count evaluations once per individual
                         evals_this_gen += len(invalid_ind)
 
                 # After evaluation, update NeuralSeeder with fresh data and optionally reseed on stagnation


### PR DESCRIPTION
## Summary
- Correct evaluation counting when the GA falls back to evaluating all invalid individuals to prevent inflated metrics that degraded adaptive behavior

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d6bd2d64832e849dfcbb262cbdf1