### PR TITLE
Expand omega sensitivity metrics

### DIFF
--- a/codes/gui/main_window/omega_sensitivity_mixin.py
+++ b/codes/gui/main_window/omega_sensitivity_mixin.py
@@ -185,20 +185,26 @@ class OmegaSensitivityMixin:
         
         # Show result details in a formatted table
         self.sensitivity_results_text.append("--- Detailed Results ---")
-        self.sensitivity_results_text.append("Points | Max Slope | Max Rel Change")
-        self.sensitivity_results_text.append("-------|-----------|----------------")
-        
+        self.sensitivity_results_text.append("Points | Max Slope | Max Rel Change | Peak Pos Δ | Bandwidth Δ")
+        self.sensitivity_results_text.append("-------|-----------|----------------|------------|-------------")
+
+        peak_changes = results.get("peak_position_changes", [])
+        bw_changes = results.get("bandwidth_changes", [])
+
         for i in range(len(results["omega_points"])):
             points = results["omega_points"][i]
             slope = results["max_slopes"][i]
             change = results["relative_changes"][i] if i < len(results["relative_changes"]) else float('nan')
-            
-            if not np.isnan(change):
-                change_str = f"{change:.6f}"
-            else:
-                change_str = "N/A"
-                
-            self.sensitivity_results_text.append(f"{points:6d} | {slope:10.6f} | {change_str}")
+            peak_change = peak_changes[i] if i < len(peak_changes) else float('nan')
+            bw_change = bw_changes[i] if i < len(bw_changes) else float('nan')
+
+            change_str = f"{change:.6f}" if not np.isnan(change) else "N/A"
+            peak_str = f"{peak_change:.6f}" if not np.isnan(peak_change) else "N/A"
+            bw_str = f"{bw_change:.6f}" if not np.isnan(bw_change) else "N/A"
+
+            self.sensitivity_results_text.append(
+                f"{points:6d} | {slope:10.6f} | {change_str} | {peak_str} | {bw_str}"
+            )
                 
         # If user selected to use optimal points, update the FRF omega points setting
         if self.sensitivity_use_optimal.isChecked():

--- a/codes/modules/FRF.py
+++ b/codes/modules/FRF.py
@@ -1042,13 +1042,19 @@ def perform_omega_points_sensitivity_analysis(
     Returns:
     --------
     dict
-        Dictionary containing convergence results, optimal points, and figure object if plot_results=True
+        Dictionary containing convergence results, optimal points, and figure object if
+        plot_results=True. The results include the maximum slope, overall maximum
+        relative change across metrics, and category-specific changes for peak
+        positions and bandwidths at each iteration.
     """
     # Initialize empty lists to store results
     point_values = []
     slope_max_values = []
     # Maximum relative change across metrics for each iteration
     relative_changes = []
+    # Track category-specific changes (peak positions, bandwidths)
+    peak_position_changes = []
+    bandwidth_changes = []
     # Store the full metric dictionary for every iteration
     metrics_history = []
     
@@ -1146,11 +1152,25 @@ def perform_omega_points_sensitivity_analysis(
                 max_change = max(changes.values(), default=np.nan)
                 relative_changes.append(max_change)
 
+                # Track category-specific maximum changes
+                peak_pos_change = max(
+                    [v for k, v in changes.items() if k.startswith("peak_positions")],
+                    default=np.nan,
+                )
+                bandwidth_change = max(
+                    [v for k, v in changes.items() if k.startswith("bandwidths")],
+                    default=np.nan,
+                )
+                peak_position_changes.append(peak_pos_change)
+                bandwidth_changes.append(bandwidth_change)
+
                 if max_change < convergence_threshold and not converged:
                     converged = True
                     convergence_point = current_points
             else:
                 relative_changes.append(np.nan)
+                peak_position_changes.append(np.nan)
+                bandwidth_changes.append(np.nan)
 
             prev_metrics = current_metrics
             
@@ -1172,6 +1192,8 @@ def perform_omega_points_sensitivity_analysis(
         "omega_points": point_values,
         "max_slopes": slope_max_values,
         "relative_changes": relative_changes,
+        "peak_position_changes": peak_position_changes,
+        "bandwidth_changes": bandwidth_changes,
         "metrics_history": metrics_history,
         "optimal_points": optimal_points,
         "converged": converged,


### PR DESCRIPTION
## Summary
- Extend omega sensitivity analysis to track peak position and bandwidth changes in addition to maximum slope.
- Expose new metrics in GUI results table and plots for clearer convergence diagnostics.

## Testing
- `python -m py_compile codes/modules/FRF.py codes/gui/main_window/omega_sensitivity_mixin.py codes/gui/main_window/input_mixin.py`
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f9e700d8832ea48f6b3b30e52fc7